### PR TITLE
chore: Upgrade tslint-config-airbnb

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/smartive/tslint-config#readme",
   "dependencies": {
-    "tslint-config-airbnb": "~5.4.2",
+    "tslint-config-airbnb": "~5.7.0",
     "tslint-react": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
With `5.4.2`:

```
Warning: no-var-self rule is deprecated. Replace your usage with the TSLint no-this-assignment rule.
```

`tslint-config-airbnb` was [updated to reflect this deprecation.](https://github.com/progre/tslint-config-airbnb/commit/397e531)