### PR TITLE
feat(trailing-comma): use correct trailing comma rule

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+package-lock.json
+npm-debug.log*
+node_modules/
+.npm
+.eslintcache
+.editorconfig
+.gitignore
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ notifications:
 jobs:
   include:
     - stage: release
-      node_js: '8'
-      script: echo "Deploy with semantic release"
-      after_success: npm run semantic-release
+      node_js: '10'
+      script: npm run semantic-release

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ Force the user to add `public`, `protected` and `private` information to the
 members of a class. This leads to better readability (despite the default
 of `public`).
 
+### Trailing Comma
+
+Actually, the rule is set to the default value of `multiline: always` and `singleline: never`. But the additional
+field is set to prevent trailing commas after rest parameters (`esSpecCompliant`):
+
+```typescript
+function withComma(
+  p1: string,
+  p2: string,
+) {}
+
+function withoutComma(
+  p1: string,
+  ...rest: string[]
+) {}
+```
+
+The comma after a rest parameter will get a typescript compiler warning.
+
 ## Usage
 
 Install using NPM:

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "homepage": "https://github.com/smartive/tslint-config#readme",
   "dependencies": {
-    "tslint-config-airbnb": "~5.7.0",
-    "tslint-react": "^3.2.0"
+    "tslint-config-airbnb": "~5.9.2",
+    "tslint-react": "^3.6.0"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.1.0",
-    "semantic-release": "^11.0.1"
+    "semantic-release": "^15.6.0"
   },
   "scripts": {
     "semantic-release": "semantic-release"

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,10 @@
 {
   "extends": "tslint-config-airbnb",
   "rules": {
-    "max-line-length": [true, 125],
+    "max-line-length": [
+      true,
+      125
+    ],
     "member-ordering": [
       true,
       {
@@ -10,10 +13,29 @@
     ],
     "ordered-imports": true,
     "no-increment-decrement": false,
-    "typedef": [true, "call-signature", "parameter", "property-declaration", "member-variable-declaration"],
-    "variable-name": [true, "check-format", "ban-keywords", "allow-leading-underscore"],
+    "typedef": [
+      true,
+      "call-signature",
+      "parameter",
+      "property-declaration",
+      "member-variable-declaration"
+    ],
+    "variable-name": [
+      true,
+      "check-format",
+      "ban-keywords",
+      "allow-leading-underscore"
+    ],
     "no-boolean-literal-compare": false,
     "strict-boolean-expressions": false,
-    "member-access": true
+    "member-access": true,
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "always",
+        "singleline": "never",
+        "esSpecCompliant": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
Adhere to the compiler warning of the trailing comma when a rest parameter is used.

Example: https://github.com/smartive/giuseppe/blob/develop/src/core/controller/GiuseppeApiController.ts#L38